### PR TITLE
Replace which with command since which is not available in the kibana image

### DIFF
--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -143,7 +143,7 @@ QUIET=${QUIET:-0}
 
 # check to see if timeout is from busybox?
 # check to see if timeout is from busybox?
-TIMEOUT_PATH=$(realpath $(which timeout))
+TIMEOUT_PATH=$(realpath $(command -v timeout))
 if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
         ISBUSY=1
         BUSYTIMEFLAG="-t"


### PR DESCRIPTION
( seriously ?? )

```
>>> kubectl logs -n monitoring elasticsearch-log-kibana-79d54575b-kvxm4 -c kibana                                                                      /opt/wait-for-it.sh: line 146: which: command not found                                                                                                               realpath: missing operand                                                                                                                                             Try 'realpath --help' for more information.                                                                                                                           /opt/wait-for-it.sh: line 146: which: command not found                                                                                                               
realpath: missing operand                                                                                                                                             Try 'realpath --help' for more information.                                                                                                                           wait-for-it.sh: waiting 15 seconds for localhost:5601
```